### PR TITLE
[log-parser] Add .general.whitelisted_domains[] config for PTR

### DIFF
--- a/source/log-parser/log-parser.py
+++ b/source/log-parser/log-parser.py
@@ -18,6 +18,7 @@ import json
 import logging
 import datetime
 import time
+import socket
 from os import environ
 from ipaddress import ip_address
 from botocore.config import Config
@@ -527,6 +528,21 @@ def get_outstanding_requesters(bucket_name, key_name, log_type):
     except Exception as e:
         logging.getLogger().error("[get_outstanding_requesters] \tError to read input file")
         logging.getLogger().error(e)
+
+    if 'whitelisted_domains' in config['general'] and len(config['general']['whitelisted_domains']) > 0:
+        #--------------------------------------------------------------------------------------------------------------
+        logging.getLogger().info("[get_outstanding_requesters] \tRemove whitelisted domains PTR")
+        #--------------------------------------------------------------------------------------------------------------
+        for k in outstanding_requesters['general'][k]:
+            hostname=socket.gethostbyaddr(k)[0]
+            if any(s in hostname for s in config['general']['whitelisted_domains']):
+                outstanding_requesters['general'].pop(k)
+
+        for uri in outstanding_requesters['uriList']:
+            for k in uri:
+                hostname=socket.gethostbyaddr(k)[0]
+                if any(s in hostname for s in config['general']['whitelisted_domains']):
+                    outstanding_requesters['uriList'][uri].pop(k)
 
     logging.getLogger().debug('[get_outstanding_requesters] End')
     return outstanding_requesters

--- a/source/log-parser/log-parser.py
+++ b/source/log-parser/log-parser.py
@@ -533,15 +533,23 @@ def get_outstanding_requesters(bucket_name, key_name, log_type):
         #--------------------------------------------------------------------------------------------------------------
         logging.getLogger().info("[get_outstanding_requesters] \tRemove whitelisted domains PTR")
         #--------------------------------------------------------------------------------------------------------------
-        for k in outstanding_requesters['general'][k]:
-            hostname=socket.gethostbyaddr(k)[0]
+        for k in outstanding_requesters['general']:
+            try:
+                hostname=socket.gethostbyaddr(k)[0]
+            except Exception as e:
+                continue
             if any(s in hostname for s in config['general']['whitelisted_domains']):
+                logging.getLogger().info("[get_outstanding_requesters] \tRemove whitelisted domains PTR : %s - %s"%(k,hostname))
                 outstanding_requesters['general'].pop(k)
 
         for uri in outstanding_requesters['uriList']:
             for k in uri:
-                hostname=socket.gethostbyaddr(k)[0]
+                try:
+                    hostname=socket.gethostbyaddr(k)[0]
+                except Exception as e:
+                    continue
                 if any(s in hostname for s in config['general']['whitelisted_domains']):
+                    logging.getLogger().info("[get_outstanding_requesters] \tRemove whitelisted domains PTR : %s - %s"%(k,hostname))
                     outstanding_requesters['uriList'][uri].pop(k)
 
     logging.getLogger().debug('[get_outstanding_requesters] End')


### PR DESCRIPTION
*treat Issue: #86

This create a new option .general.whitelisted_domains[] : a list of PTR domains that cannot be blocked by log-parser. 
example : {"general": {"errorThreshold": 50, "blockPeriod": 120, "errorCodes": ["400", "401", "403", "404", "405"], "whitelisted_domains": ["search.msn.com", "spider.yandex.com", ".googlebot.com"]}, "uriList": {}}

So chosen domains like googlebot IP ranges are not blocked if it reach some threshold
When outstanding_requesters is done before merge with existing list. reverse resolution is done on each IP address. and exclude from the object.

No need to query whois and add ranges on whitelist IP set (this could be some improuvment if load on big outstanding_requesters object is heavy).
