### PR TITLE
add `BucketEncryption` (AES) to `WafLogBucket`

### DIFF
--- a/deployment/aws-waf-security-automations.template
+++ b/deployment/aws-waf-security-automations.template
@@ -361,6 +361,10 @@ Resources:
     DeletionPolicy: Retain
     Properties:
       AccessControl: Private
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
       PublicAccessBlockConfiguration:
         BlockPublicAcls: true
         BlockPublicPolicy: true


### PR DESCRIPTION
*Issue #, if available:*
The S3 Bucket created by the stack for WAF Logs for the HTTP Flood Parser and the Athena result sets is not encrypted by default.

See: https://github.com/awslabs/aws-waf-security-automations/issues/109

*Description of changes:*
Added S3 Bucket BucketEncryption property to the WafLogBucket resource.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
