### PR TITLE
Issue #142 RuleGroup for FW Manager

### DIFF
--- a/deployment/aws-waf-security-automations-webacl.template
+++ b/deployment/aws-waf-security-automations-webacl.template
@@ -605,6 +605,121 @@ Resources:
                           Type: HTML_ENTITY_DECODE
           - !Ref 'AWS::NoValue'
 
+  WAFRuleGroup:
+    Type: AWS::WAFv2::RuleGroup
+    Properties:
+      Name: !Sub '${ParentStackName}RuleGroup'
+      Description: 'Custom WAF RuleGroup for use in Firewall Manager. Excludes Rate, XSS and SQL Injection rules, they can be included separately if needed'
+      Scope: !Sub '${RegionScope}'
+      Capacity: 100
+      VisibilityConfig: 
+        SampledRequestsEnabled: true
+        CloudWatchMetricsEnabled: true
+        MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'WAFRuleGroup']]
+      Rules:
+        - Name: !Sub '${ParentStackName}WhitelistRule'
+          Priority: 1
+          Action:
+            Allow: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'WhitelistRule']]
+          Statement:
+            OrStatement:
+              Statements:
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFWhitelistSetV4.Arn
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFWhitelistSetV6.Arn
+        - Name: !Sub '${ParentStackName}BlacklistRule'
+          Priority: 2
+          Action:
+            Block: {}
+          VisibilityConfig:
+            SampledRequestsEnabled: true
+            CloudWatchMetricsEnabled: true
+            MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'BlacklistRule']]
+          Statement:
+            OrStatement:
+              Statements:
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFBlacklistSetV4.Arn
+                - IPSetReferenceStatement:
+                    Arn: !GetAtt WAFBlacklistSetV6.Arn
+        - !If
+          - HttpFloodProtectionLogParserActivated
+          - Name: !Sub '${ParentStackName}HttpFloodRegularRule'
+            Priority: 3
+            Action:
+              Block: {}
+            VisibilityConfig:
+              SampledRequestsEnabled: true
+              CloudWatchMetricsEnabled: true
+              MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'HttpFloodRegularRule']]
+            Statement:
+              OrStatement:
+                Statements:
+                  - IPSetReferenceStatement:
+                      Arn: !GetAtt WAFHttpFloodSetV4.Arn
+                  - IPSetReferenceStatement:
+                      Arn: !GetAtt WAFHttpFloodSetV6.Arn
+          - !Ref 'AWS::NoValue'
+        - !If
+          - ScannersProbesProtectionActivated
+          - Name: !Sub '${ParentStackName}ScannersAndProbesRule'
+            Priority: 5
+            Action:
+              Block: {}
+            VisibilityConfig:
+              SampledRequestsEnabled: true
+              CloudWatchMetricsEnabled: true
+              MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'ScannersProbesRule']]
+            Statement:
+              OrStatement:
+                Statements:
+                  - IPSetReferenceStatement:
+                      Arn: !GetAtt WAFScannersProbesSetV4.Arn
+                  - IPSetReferenceStatement:
+                      Arn: !GetAtt WAFScannersProbesSetV6.Arn
+          - !Ref 'AWS::NoValue'
+        - !If
+          - ReputationListsProtectionActivated
+          - Name: !Sub '${ParentStackName}IPReputationListsRule'
+            Priority: 6
+            Action:
+              Block: {}
+            VisibilityConfig:
+              SampledRequestsEnabled: true
+              CloudWatchMetricsEnabled: true
+              MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'IPReputationListsRule']]
+            Statement:
+              OrStatement:
+                Statements:
+                  - IPSetReferenceStatement:
+                      Arn: !GetAtt WAFReputationListsSetV4.Arn
+                  - IPSetReferenceStatement:
+                      Arn: !GetAtt WAFReputationListsSetV6.Arn
+          - !Ref 'AWS::NoValue'
+        - !If
+          - BadBotProtectionActivated
+          - Name: !Sub '${ParentStackName}BadBotRule'
+            Priority: 7
+            Action:
+              Block: {}
+            VisibilityConfig:
+              SampledRequestsEnabled: true
+              CloudWatchMetricsEnabled: true
+              MetricName: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'BadBotRule']]
+            Statement:
+              OrStatement:
+                Statements:
+                  - IPSetReferenceStatement:
+                      Arn: !GetAtt WAFBadBotSetV4.Arn
+                  - IPSetReferenceStatement:
+                      Arn: !GetAtt WAFBadBotSetV6.Arn
+          - !Ref 'AWS::NoValue'
+
 Outputs:
 # Arns
   WAFWhitelistSetV4Arn:
@@ -710,6 +825,13 @@ Outputs:
 
   WAFWebACLArn:
     Value: !GetAtt WAFWebACL.Arn
+
+  WAFRuleGroup:
+    Value: !Ref WAFRuleGroup
+
+  WAFRuleGroupArn:
+    Value: !GetAtt WAFRuleGroup.Arn
+
 
   WAFWebACLMetricName:
     Value: !Join ['', [!Join ['', !Split ['-', !Ref ParentStackName]], 'MaliciousRequesters']]

--- a/deployment/aws-waf-security-automations.template
+++ b/deployment/aws-waf-security-automations.template
@@ -47,6 +47,7 @@ Metadata:
           - ErrorThreshold
           - RequestThreshold
           - WAFBlockPeriod
+          - BadBotBlockPeriod
           - KeepDataInOriginalS3Location
 
     ParameterLabels:
@@ -85,6 +86,9 @@ Metadata:
 
       WAFBlockPeriod:
         default: WAF Block Period
+
+      BadBotBlockPeriod:
+        default: Bad Bot Block Period
 
       KeepDataInOriginalS3Location:
         default: Keep Data in Original s3 location
@@ -197,6 +201,15 @@ Parameters:
       If you chose yes for the Activate Scanners & Probes Protection or HTTP Flood Lambda/Athena log
       parser parameters, enter the period (in minutes) to block applicable IP addresses. If you
       chose to deactivate log parsing, ignore this parameter.
+
+  BadBotBlockPeriod:
+    Type: Number
+    Default: 14400
+    MinValue: 0
+    Description: >-
+      The period in seconds that an offending IP will remain in the Bad Bots IP List before it is 
+      automatically removed. If you choose not to activate the bat bot protection,
+      ignore this parameter.
 
   KeepDataInOriginalS3Location:
     Type: String
@@ -461,6 +474,19 @@ Resources:
                 Action: 'cloudwatch:GetMetricStatistics'
                 Resource:
                   - '*'
+        - PolicyName: StepFunctionAccess
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: 
+                  - 'states:StartExecution'
+                  - 'states:ListExecutions'
+                Resource:
+                  - !Sub 'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:BadBotUnblockIP-${AWS::StackName}-%VERSION%'
+              - Effect: Allow
+                Action: 'states:StopExecution'
+                Resource: '*'
+
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -1391,10 +1417,60 @@ Resources:
           SOLUTION_ID: !FindInMap [Solution, Data, SolutionID]
           METRICS_URL: !FindInMap [Solution, Data, MetricsURL]
           STACK_NAME: !Ref 'AWS::StackName'
+          UNBLOCK_IP_STATE_MACHINE_ARN: !Sub 'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:BadBotUnblockIP-${AWS::StackName}-%VERSION%'
 
       Runtime: python3.8
       MemorySize: 128
       Timeout: 300
+  
+  BadBotUnblockIPStateMachine:
+    Type: "AWS::StepFunctions::StateMachine"
+    Condition: BadBotProtectionActivated
+    Properties:
+      # Hard coded name is defined here to get around Circular dependency between StateMachine and Lambda function.
+      StateMachineName: !Sub 'BadBotUnblockIP-${AWS::StackName}-%VERSION%'
+      DefinitionString:
+        !Sub
+          - |-
+            {
+             "StartAt": "WaitForTime",
+              "States": {
+                  "WaitForTime": {
+                    "Type": "Wait",
+                    "Seconds": ${BadBotBlockPeriodSeconds},
+                    "Next": "UnblockIP"
+                  },
+              "UnblockIP": {
+                      "Type": "Task",
+                      "Resource": "${lambdaArn}",
+                      "End": true
+                  }
+              }
+            }
+          - { lambdaArn: !GetAtt [ BadBotParser, Arn ], BadBotBlockPeriodSeconds: !Ref BadBotBlockPeriod }
+      RoleArn: !GetAtt [ StateMachineRoleUnlockBadBotIP, Arn ]
+
+  StateMachineRoleUnlockBadBotIP:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - !Sub states.${AWS::Region}.amazonaws.com
+            Action: "sts:AssumeRole"
+      Path: "/"
+      Policies:
+        - PolicyName: StatesExecutionPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "lambda:InvokeFunction"
+                Resource: !GetAtt [ BadBotParser, Arn ]
 
   LambdaInvokePermissionBadBot:
     Type: 'AWS::Lambda::Permission'


### PR DESCRIPTION
*Issue #142*

*Description of changes:*
Added a RuleGroup to the WAF template that allows use of some of the automations such as BadBot List in Firewall Manager, meaning that an bad bot IP hitting the honeypot will be added to a deny list that will then block the IP access across all attached cloudfront distributions in multiple accounts (or ALBs or whatever).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
