### PR TITLE
Issue #147 Unblock BadBot IP after a while

### DIFF
--- a/deployment/aws-waf-security-automations.template
+++ b/deployment/aws-waf-security-automations.template
@@ -47,6 +47,7 @@ Metadata:
           - ErrorThreshold
           - RequestThreshold
           - WAFBlockPeriod
+          - BadBotBlockPeriod
           - KeepDataInOriginalS3Location
 
     ParameterLabels:
@@ -85,6 +86,9 @@ Metadata:
 
       WAFBlockPeriod:
         default: WAF Block Period
+
+      BadBotBlockPeriod:
+        default: Bad Bot Block Period
 
       KeepDataInOriginalS3Location:
         default: Keep Data in Original s3 location
@@ -197,6 +201,15 @@ Parameters:
       If you chose yes for the Activate Scanners & Probes Protection or HTTP Flood Lambda/Athena log
       parser parameters, enter the period (in minutes) to block applicable IP addresses. If you
       chose to deactivate log parsing, ignore this parameter.
+
+  BadBotBlockPeriod:
+    Type: Number
+    Default: 14400
+    MinValue: 0
+    Description: >-
+      The period in seconds that an offending IP will remain in the Bad Bots IP List before it is 
+      automatically removed. If you choose not to activate the bat bot protection,
+      ignore this parameter.
 
   KeepDataInOriginalS3Location:
     Type: String
@@ -461,6 +474,19 @@ Resources:
                 Action: 'cloudwatch:GetMetricStatistics'
                 Resource:
                   - '*'
+        - PolicyName: StepFunctionAccess
+          PolicyDocument:
+            Statement:
+              - Effect: Allow
+                Action: 
+                  - 'states:StartExecution'
+                  - 'states:ListExecutions'
+                Resource:
+                  - !Sub 'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:BadBotUnblockIP-${AWS::StackName}-%VERSION%'
+              - Effect: Allow
+                Action: 'states:StopExecution'
+                Resource: '*'
+
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -1391,10 +1417,60 @@ Resources:
           SOLUTION_ID: !FindInMap [Solution, Data, SolutionID]
           METRICS_URL: !FindInMap [Solution, Data, MetricsURL]
           STACK_NAME: !Ref 'AWS::StackName'
+          UNBLOCK_IP_STATE_MACHINE_ARN: !Sub 'arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:BadBotUnblockIP-${AWS::StackName}-%VERSION%'
 
       Runtime: python3.8
       MemorySize: 128
       Timeout: 300
+  
+  BadBotUnblockIPStateMachine:
+    Type: "AWS::StepFunctions::StateMachine"
+    Condition: BadBotProtectionActivated
+    Properties:
+      # Hard coded name is defined here to get around Circular dependency between StateMachine and Lambda function.
+      StateMachineName: !Sub 'BadBotUnblockIP-${AWS::StackName}-%VERSION%'
+      DefinitionString:
+        !Sub
+          - |-
+            {
+             "StartAt": "WaitForTime",
+              "States": {
+                  "WaitForTime": {
+                    "Type": "Wait",
+                    "Seconds": ${BadBotBlockPeriodSeconds},
+                    "Next": "UnblockIP"
+                  },
+              "UnblockIP": {
+                      "Type": "Task",
+                      "Resource": "${lambdaArn}",
+                      "End": true
+                  }
+              }
+            }
+          - { lambdaArn: !GetAtt [ BadBotParser, Arn ], BadBotBlockPeriodSeconds: !Ref BadBotBlockPeriod }
+      RoleArn: !GetAtt [ StateMachineRoleUnlockBadBotIP, Arn ]
+
+  StateMachineRoleUnlockBadBotIP:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              Service:
+                - !Sub states.${AWS::Region}.amazonaws.com
+            Action: "sts:AssumeRole"
+      Path: "/"
+      Policies:
+        - PolicyName: StatesExecutionPolicy
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - "lambda:InvokeFunction"
+                Resource: !GetAtt [ BadBotParser, Arn ]
 
   LambdaInvokePermissionBadBot:
     Type: 'AWS::Lambda::Permission'

--- a/source/access_handler/access-handler.py
+++ b/source/access_handler/access-handler.py
@@ -199,17 +199,28 @@ def lambda_handler(event, context):
         ipset_name_v6 = os.getenv('IP_SET_NAME_BAD_BOTV6')
         ipset_arn_v4 = os.getenv('IP_SET_ID_BAD_BOTV4')
         ipset_arn_v6 = os.getenv('IP_SET_ID_BAD_BOTV6')
+        unblock_state_machine_arn = os.getenv('UNBLOCK_IP_STATE_MACHINE_ARN')
 
         # Fixed as old line had security exposure based on user supplied IP address
         log.info("Event->%s<-", str(event))
-        source_ip = str(event['requestContext']['identity']['sourceIp'])
+        source_ip = ''
+        block = True
+        # favour code readbility over shortcuts
+        if event.get("unblock"):
+            source_ip = event['source_ip'] 
+            block = False
+        else:            
+            source_ip = event['headers']['X-Forwarded-For'].split(',')[0].strip() \
+                if event['headers'].get('X-Forwarded-For') \
+                    else str(event['requestContext']['identity']['sourceIp'])
 
         log.info("scope = %s", scope)
         log.info("ipset_name_v4 = %s", ipset_name_v4)
         log.info("ipset_name_v6 = %s", ipset_name_v6)
         log.info("IPARNV4 = %s", ipset_arn_v4)
         log.info("IPARNV6 = %s", ipset_arn_v6)
-        log.info("source_ip = %s", source_ip)
+        log.info("UNBLOCK_IP_STATE_MACHINE_ARN = %s", unblock_state_machine_arn)
+        log.info("%s source_ip = %s", ("Block" if block else "Unblock"), source_ip)
     except Exception as e:
         log.error(e)
         raise
@@ -225,7 +236,7 @@ def lambda_handler(event, context):
             log.info(ipset)
             current_list = ipset["IPSet"]["Addresses"]
             log.info(current_list)
-            new_list = list(set(current_list) | set(new_address))
+            new_list = list(set(current_list) | set(new_address)) if block else list(set(current_list) - set(new_address))
             log.info(new_list)
             output = waflib.update_ip_set(log, scope, ipset_name_v4, ipset_arn_v4, new_list)
         elif ip_type == "IPV6":
@@ -236,9 +247,11 @@ def lambda_handler(event, context):
             log.info(ipset)
             current_list = ipset["IPSet"]["Addresses"]
             log.info(current_list)
-            new_list = list(set(current_list) | set(new_address))
+            new_list = list(set(current_list) | set(new_address)) if block else list(set(current_list) - set(new_address))
             log.info(new_list)
             output = waflib.update_ip_set(log, scope, ipset_name_v6, ipset_arn_v6, new_list)
+        if block:
+            setup_unblock_future_execution(ip_type, source_ip, unblock_state_machine_arn, log)
     except Exception as e:
         log.error(e)
         raise
@@ -256,3 +269,50 @@ def lambda_handler(event, context):
     log.info('[lambda_handler] End')
 
     return response
+
+#======================================================================================================================
+# Step Function to wait for a while before it invokes this Lambda again to unblock the IP from Bad Bot blocked IP list
+#======================================================================================================================
+def setup_unblock_future_execution(ip_type, source_ip, arn, log):
+    time_now = datetime.datetime.utcnow()
+    # granularity of 1 minute is sufficient. Normally a bot would be blocked from making further requests,
+    # but if for some reason further requests are made the unblock step function exeuction is effectively 
+    # "moved forward" so that the IP is not unblocked until xx seconds after the last "hit"
+    time_stamp = time_now.strftime("%Y%m%d%H%M")
+
+    prefix = source_ip.replace(':', '-').replace('.', '-')
+    name_of_execution = prefix + '-' + time_stamp
+
+    log.info("execution name: {}".format(prefix))
+    ip_to_pass = {
+        "unblock": "true", 
+        "source_ip": source_ip
+    }
+    stepfunctions = boto3.client('stepfunctions')
+
+    response = stepfunctions.list_executions(
+        stateMachineArn=arn,
+        statusFilter='RUNNING',
+        maxResults=1000)
+    
+    log.debug(response)
+    if response.get('executions'):
+        previous = [v for v in response['executions'] if v['name'].startswith(prefix) and v['name'] < name_of_execution]
+        log.debug(previous)
+    
+        if previous:
+            arn_to_be_cancelled = previous[0]['executionArn']
+            log.info("About to cancel execution {}".format(arn_to_be_cancelled))
+            try:
+                cancel_previous = stepfunctions.stop_execution(executionArn=arn_to_be_cancelled, cause="push unblock time forward")
+                log.debug(cancel_previous)
+                log.info("Previous Unblock of IP %s Aborted, Timer being reset", source_ip)
+            except:
+                log.info("Previous execution for ip {} did not abort successfully".format(source_ip), exc_info=True)
+
+    response = stepfunctions.start_execution(
+        stateMachineArn=arn,
+        name=name_of_execution,
+        input=json.dumps(ip_to_pass)
+        )
+    log.debug("Response from State Machine: {}".format(response))


### PR DESCRIPTION

Issue #147 and #136

*Description of changes:
Automatically remove IPs from the Bad Bot List after a specified period using a Step Function and delay. If the same bad bot hits again from the same IP, the timer is reset, so the IP is not removed from the bad bot list until the full period has elapsed since the hit. Also fixed the issue with CloudFront IPs being blocked by obtaining source ip from the X-Forwarded-For header.*

For some reason whitespace changed in nearly all lines in the template, but you can ignore whitespace and compare the actual changes by suffixing ?w=1 in the github url - see 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.