### PR TITLE
Add CloudFront function for injecting True-Client-Ip header to propely record client IP

### DIFF
--- a/deployment/aws-waf-security-automations.template
+++ b/deployment/aws-waf-security-automations.template
@@ -1357,6 +1357,22 @@ Resources:
       Principal: events.amazonaws.com
       SourceArn: !GetAtt ReputationListsParserEventsRule.Arn
 
+  InjectTrueClientIP:
+    Type: AWS::CloudFront::Function
+    Properties:
+      Name: InjectTrueClientIP
+      AutoPublish: True
+      FunctionConfig:
+        Comment: Injects the True-Client-Ip header to all requests.
+        Runtime: cloudfront-js-1.0
+      FunctionCode: |-
+        function handler(event) {
+            var request = event.request;
+            var clientIP = event.viewer.ip;
+            request.headers['True-Client-Ip'] = { value: clientIP };
+            return request;
+        }
+
   BadBotParser:
     Type: 'AWS::Lambda::Function'
     Condition: BadBotProtectionActivated
@@ -1432,7 +1448,7 @@ Resources:
       HttpMethod: ANY
       AuthorizationType: NONE
       RequestParameters:
-        method.request.header.X-Forwarded-For: false
+        method.request.header.True-Client-Ip: false
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
@@ -1454,7 +1470,7 @@ Resources:
       HttpMethod: ANY
       AuthorizationType: NONE
       RequestParameters:
-        method.request.header.X-Forwarded-For: false
+        method.request.header.True-Client-Ip: false
       Integration:
         Type: AWS_PROXY
         IntegrationHttpMethod: POST
@@ -1721,6 +1737,10 @@ Resources:
               RegionProperties: !If [AlbEndpoint, !Sub '${AWS::Region}', 'us-east-1']
 
 Outputs:
+  InjectTrueClientIPArn:
+    Description: CloudFront Function ARN to inject True-Client-Ip header
+    Value: !GetAtt InjectTrueClientIP.FunctionARN
+
   BadBotHoneypotEndpoint:
     Description: Bad Bot Honeypot Endpoint
     Value: !Sub 'https://${ApiGatewayBadBot}.execute-api.${AWS::Region}.amazonaws.com/${ApiGatewayBadBotStage}'

--- a/source/access_handler/access-handler.py
+++ b/source/access_handler/access-handler.py
@@ -200,9 +200,8 @@ def lambda_handler(event, context):
         ipset_arn_v4 = os.getenv('IP_SET_ID_BAD_BOTV4')
         ipset_arn_v6 = os.getenv('IP_SET_ID_BAD_BOTV6')
 
-        # Fixed as old line had security exposure based on user supplied IP address
         log.info("Event->%s<-", str(event))
-        source_ip = str(event['requestContext']['identity']['sourceIp'])
+        source_ip = str(event['headers']['True-Client-Ip'])
 
         log.info("scope = %s", scope)
         log.info("ipset_name_v4 = %s", ipset_name_v4)


### PR DESCRIPTION
*Issue #, if available:* #136

This resolves the issue reported as in #136 - which was introduced in pull request #123 - by changing instead to relying on a different header `True-Client-Ip` and [a CloudFront function to inject the value based on the client IP](https://github.com/aws-samples/amazon-cloudfront-functions/blob/main/add-true-client-ip-header/index.js).

Obviously the disadvantage here is that it means there is a further step to getting everything working because when creating the CloudFront distribution cache behaviour you need to specify a function association using the ARN from the new output `InjectTrueClientIPArn` to actually get the header injected, but given that the bad bot protection just doesn't work at all at the moment, and the use of `X-Forwarded-For` for this purpose is insecure (as mentioned in pull request #123 itself), I think it's a good compromise that doesn't introduce a vulnerability.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
