### PR TITLE
Updated to version v3.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.3] - 2022-12-13
+### Changed
+- Add region as prefix to application attribute group name to avoid conflict with name starting with AWS.
 ## [3.2.2] - 2022-12-05
 ### Added
 - Added AppRegistry integration

--- a/deployment/aws-waf-security-automations.template
+++ b/deployment/aws-waf-security-automations.template
@@ -2272,7 +2272,7 @@ Resources:
   DefaultApplicationAttributes:
     Type: AWS::ServiceCatalogAppRegistry::AttributeGroup
     Properties:
-      Name: !Ref AWS::StackName
+      Name: !Sub '${AWS::Region}-${AWS::StackName}'
       Description: Attribute group for solution information.
       Attributes:       
         { "ApplicationType" : 'AWS-Solutions',


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add region as prefix to application attribute group name to avoid conflict with name starting with AWS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
