### PR TITLE
Set S3 ObjectOwnership to ObjectWriter for AccessLoggingBucket

### DIFF
--- a/deployment/aws-waf-security-automations.template
+++ b/deployment/aws-waf-security-automations.template
@@ -1289,6 +1289,9 @@ Resources:
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
     Properties:
+      OwnershipControls:
+        Rules:
+          - ObjectOwnership: ObjectWriter
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:


### PR DESCRIPTION
Closes #236 

Starting in April 2023, S3 changed the default ownership settings for new S3 buckets:

https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/

By not specifying ObjectWriter as the desired ownership the bucket defaulted to the new BucketOwnerEnforced. This caused the CF template to fail creating the S3 bucket when it tries to apply ACL rules on the bucket. The template would fail with this error

```
Bucket cannot have ACLs set with ObjectOwnership's BucketOwnerEnforced setting
```

By specifying that the bucket should be created with ObjectWriter (ACL enabled) the CF template is then able to apply it's ACL rules and successfully deploy.

As of this commit (April 18, 2023) this cf template fails to deploy in us-east-2. I'm guessing this is the first, or one of the first, regions where these new defaults are being rolled out to.

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
