### PR TITLE
Make the AppRegistry conditional

### DIFF
--- a/deployment/aws-waf-security-automations.template
+++ b/deployment/aws-waf-security-automations.template
@@ -18,6 +18,10 @@ Metadata:
         Parameters:
           - EndpointType
       - Label:
+          default: AppRegistry Integration
+        Parameters:
+          - AppRegistryIntegrationParam
+      - Label:
           default: AWS Managed IP Reputation Rule Groups
         Parameters:
           - ActivateAWSManagedIPRParam
@@ -82,6 +86,9 @@ Metadata:
           - LogGroupRetentionParam
 
     ParameterLabels:
+      AppRegistryIntegrationParam:
+        default: Include the AppRegistry Integration
+
       ActivateAWSManagedRulesParam:
         default: Activate Core Rule Set Managed Rule Group Protection
 
@@ -186,6 +193,18 @@ Metadata:
 
 
 Parameters:
+  AppRegistryIntegrationParam:
+    Type: String
+    Default: 'yes'
+    AllowedValues:
+      - 'yes'
+      - 'no'
+    Description: >-
+      The App Registry Integration provides access to the WAF Stack information via
+      the AWS Systems Manager App Manager tools, which are available in most regions.
+      This should be disabled if that is not available in the region into which you
+      are deploying the stack.
+
   ActivateAWSManagedRulesParam:
     Type: String
     Default: 'no'
@@ -590,6 +609,14 @@ Parameters:
       keep the logs indefinitely.
 
 Conditions:
+  IncludeAppRegistry: !Equals
+    - !Ref AppRegistryIntegrationParam
+    - 'yes'
+
+  IncludeAppRegistryAndCreateFirehoseAthenaStack: !And
+    - Condition: IncludeAppRegistry
+    - Condition: CreateFirehoseAthenaStack
+
   HttpFloodProtectionRateBasedRuleActivated: !Equals
     - !Ref ActivateHttpFloodProtectionParam
     - 'yes - AWS WAF rate based rule'
@@ -2697,6 +2724,7 @@ Resources:
   # AppRegistry Application
   Application:
     Type: AWS::ServiceCatalogAppRegistry::Application
+    Condition: IncludeAppRegistry
     Properties:
       Description: Service Catalog application to track and manage all your resources for the solution WAF Security Automations. The SolutionID is SO0006 and SolutionVersion is %VERSION%.
       Name: 
@@ -2715,6 +2743,7 @@ Resources:
 
   AppRegistryApplicationStackAssociation:
     Type: AWS::ServiceCatalogAppRegistry::ResourceAssociation
+    Condition: IncludeAppRegistry
     Properties:
       Application: !GetAtt Application.Id
       Resource:
@@ -2723,6 +2752,7 @@ Resources:
 
   AppRegistryApplicationStackAssociationNestedStackWebACL:
     Type: AWS::ServiceCatalogAppRegistry::ResourceAssociation
+    Condition: IncludeAppRegistry
     Properties:
       Application: !GetAtt Application.Id
       Resource: 
@@ -2731,7 +2761,7 @@ Resources:
 
   AppRegistryApplicationStackAssociationNestedStackFirehoseAthena:
     Type: AWS::ServiceCatalogAppRegistry::ResourceAssociation
-    Condition: CreateFirehoseAthenaStack
+    Condition: IncludeAppRegistryAndCreateFirehoseAthenaStack
     Properties:
       Application: !GetAtt Application.Id
       Resource: 
@@ -2740,6 +2770,7 @@ Resources:
 
   DefaultApplicationAttributeGroup:
     Type: AWS::ServiceCatalogAppRegistry::AttributeGroup
+    Condition: IncludeAppRegistry
     Properties:
       Name: !Sub 'AttrGrp-${AWS::Region}-${AWS::StackName}'
       Description: Attribute group for solution information.
@@ -2752,6 +2783,7 @@ Resources:
 
   AppRegistryApplicationAttributeAssociation:
     Type: AWS::ServiceCatalogAppRegistry::AttributeGroupAssociation
+    Condition: IncludeAppRegistry
     Properties:
       Application: !GetAtt Application.Id
       AttributeGroup: !GetAtt DefaultApplicationAttributeGroup.Id


### PR DESCRIPTION
Make the AppRegistry conditional, but default to being on,so this solution can be deployed to a region where the AWS Service Catalog AppRegistry is not available.

*Issue # 253*

*Description of changes:* Add a condition so that the AppRegistry integration can be left out when AppRegistry is not available (or if the user does not want it).

Using this change a a private deployment of all the resources into S3 I was able to launch the stack in il-central-1 where AppRegistry is not available (at least not at present).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.